### PR TITLE
修正gtkw输出路径 修正输出的波形文件缺少数据的问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(1): $(OBJ)/$(1)/V$(2)
 	$$< | tee $(OUT)/$(1)/run.log
 $(OBJ)/$(1)/V$(2): $(TOP) $(1).tb.cpp
 	@mkdir -p $(OBJ)/$(1) $(SCORE_PREFIX)
-	verilator --cc --trace --exe -Wno-fatal -Mdir $(OBJ)/$(1) -DN=$(N) -CFLAGS "-DSCORE_PREFIX=\"\\\"$(SCORE_PREFIX)\\\"\"" --top $(2) $$^
+	verilator --cc --trace  --trace-max-array 1024 --trace-max-width 1024 --trace-depth 99 --exe -Wno-fatal -Mdir $(OBJ)/$(1) -DN=$(N) -CFLAGS "-DSCORE_PREFIX=\"\\\"$(SCORE_PREFIX)\\\"\"" --top $(2) $$^
 	+$(MAKE) -C $(OBJ)/$(1) -f V$(2).mk
 endef
 $(eval $(call gen_verilator_target_mk,RedUnit,RedUnit))

--- a/SpMM2.tb.cpp
+++ b/SpMM2.tb.cpp
@@ -814,7 +814,7 @@ int main(int argc, char ** argv) {
     auto dut = std::make_unique<DUT>();
     dut->init();
     int num_el = dut->num_el;
-    generate_gtkw_file("trace/SpMM/wave.gtkw", num_el);
+    generate_gtkw_file("trace/SpMM2/wave.gtkw", num_el);
     std::vector<MetaTest> tests;
     auto gen_no_halo = lhs_no_halo(num_el);
     auto gen_halo = lhs_halo(num_el); 


### PR DESCRIPTION
1. 修正了tb2中gtkw的输出路径
2. 增加了verilator的trace data width，解决了波形文件缺少数据的问题